### PR TITLE
Change zoom scroll direction and speed

### DIFF
--- a/src/Maps/Internal/Screen.elm
+++ b/src/Maps/Internal/Screen.elm
@@ -131,7 +131,7 @@ decodeZoom =
 
 scrollToZoom : Float -> ZoomLevel
 scrollToZoom scroll =
-  scroll * 0.05
+  negate (scroll * 0.02)
 
 {-| Decodes a touch event into a zoom level and movement offset.
 -}


### PR DESCRIPTION
Flips the scroll and pinch direction to zoom in when scrolling up and zoom out when scrolling down. Similar to Google Maps, OSM and Mapbox maps.

Also makes the scroll or pinch actions a bit less sensitive / more subtle.