### PR TITLE
Fix Maps.Map.viewBounds docs

### DIFF
--- a/src/Maps/Map.elm
+++ b/src/Maps/Map.elm
@@ -130,7 +130,7 @@ zoomTo zoom offset = opaqueMap <| Map.zoomTo zoom offset
 
 {-| Move and zoom the map to cover given the bounds.
 
-For example, view th bounds of Madagascar:
+For example, view the bounds of Madagascar:
 
     let
       madagascar =

--- a/src/Maps/Map.elm
+++ b/src/Maps/Map.elm
@@ -135,8 +135,9 @@ For example, view th bounds of Madagascar:
     let
       madagascar =
         Maps.Geo.bounds
-          (Map.Geo.LatLng -11.9519639 50.48377989999999)
-          (Maps.Geo.LatLng -25.6065157 43.1851395)
+          { northEast = Maps.Geo.latLng -11.9519639 50.48377989999999
+          , southWest = Maps.Geo.latLng -25.6065157 43.1851395
+          }
     in
       map
       |> viewBounds madagascar


### PR DESCRIPTION
Maps.Geo.bounds consumes a record instead of two LatLngs.

Maybe changing the Maps.Geo.bounds behaviour might be preferable. 